### PR TITLE
Blockquote (>) the Brailsford quote

### DIFF
--- a/_posts/2022-06-10-the-power-of-compounding-incrementals.markdown
+++ b/_posts/2022-06-10-the-power-of-compounding-incrementals.markdown
@@ -7,7 +7,9 @@ description:
 date:   2022-06-10 10:19:13 +0000
 ---
 
-*“If you break down everything you can think of that goes into riding a bike, and then improve it by 1 percent, you will get a significant increase when you put them all together.”*  - Dave Brailsford, the coach who turned British cycling into a world-beating force.
+> If you break down everything you can think of that goes into riding a bike, and then improve it by 1 percent, you will get a significant increase when you put them all together.
+  
+_&mdash; Dave Brailsford, the coach who turned British cycling into a world-beating force._
 
 Let’s imagine a union with some fairly typical online joining stats.
 


### PR DESCRIPTION
Mostly so it shows up accessibly as a `&lt;blockquote&gt;` but also because
Mark has styled them.

Put the attribution outside as per the HTML Living Standard

https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element