### PR TITLE
Corrrect dates in posts and set up redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       terminal-table (~> 2.0)
     jekyll-feed (0.16.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
@@ -73,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ url: "https://jointogether.online"
 
 # Build settings
 plugins:
+  - jekyll-redirect-from
   - jekyll-feed
 
 collections:

--- a/_posts/2022-10-25-check-off-checking-out.markdown
+++ b/_posts/2022-10-25-check-off-checking-out.markdown
@@ -5,6 +5,10 @@ description:
   If employers (or the government) end "check-off", it could spell trouble for union finances. Here's what unions can do about it.
 og_image_path: /assets/images/posts/check-off-checking-out-social.jpg
 date: 2022-10-25 11:19:13 +0000
+redirect_from:
+  - /post/2022-25-10-check-off-checking-out
+  - /post/2022-25-10-check-off-checking-out/
+
 ---
 
 The deduction of member subscriptions directly from wages is great for union members and their unions. When you have it agreed with an employer, check-off makes signing up new members easy, collecting their subs automatic, means members never need to worry about renewals or failing payment methods ensures subscription fees reflect the member’s increasing wages, so they’re always paying their fair share. It also means unions can collect subs with minimal bureaucracy and cost (such as banking fees), as they get all their subs in a lump sum.

--- a/_posts/2022-10-27-dealing-with-bad-employers.markdown
+++ b/_posts/2022-10-27-dealing-with-bad-employers.markdown
@@ -4,6 +4,9 @@ title:  "Dealing with bad employers"
 description: "How Join Together helps improve the quality of your union's employer data"
 og_image_path: /assets/images/posts/dealing-with-bad-employers-social.jpg
 date:   2022-10-27 07:19:13 +0000
+redirect_from:
+  - /post/2022-27-10-dealing-with-bad-employers
+  - /post/2022-27-10-dealing-with-bad-employers/
 ---
 
 If you’re reading this, you’ll already know well that one of the main challenges for a union is dealing with bad employers. 


### PR DESCRIPTION
Was bothering me that these posts were appearing out-of-order because the filenames were YYYY-DD-MM and not YYYY-MM-DD.