### PR TITLE
New landing page and content jigging

### DIFF
--- a/_corporate-pages/team.markdown
+++ b/_corporate-pages/team.markdown
@@ -7,6 +7,10 @@ description:
 footer-order: "2"
 ---
 
+We started Join Together as a co-operative with a focus on helping unions address the technology challenges we've seen them face over the years. And though we’re not “organisers” in the traditional sense (well, one of us is!) , we’ve come to see ourselves playing a similar role.
+
+Our mission is to make it easier to join – and stay a member of – unions. We created software that gives people a better online joining experience to help unions recruit more members, get bigger – and win.
+
 ## John Chadfield
 
 **Product Manager**

--- a/assets/jt.scss
+++ b/assets/jt.scss
@@ -471,6 +471,7 @@ header {
   strong {
     font-weight: 800;
   }
+  h2 { margin-top: 1.5em }
   #layout-inner {
     @include layout-block();
     position: relative;

--- a/assets/jt.scss
+++ b/assets/jt.scss
@@ -468,6 +468,9 @@ header {
 // LAYOUT - HOMEPAGE
 
 #layout-homepage {
+  strong {
+    font-weight: 800;
+  }
   #layout-inner {
     @include layout-block();
     position: relative;

--- a/assets/jt.scss
+++ b/assets/jt.scss
@@ -182,13 +182,13 @@ $transition: 0.3s ease;
     padding-bottom: 5px;
     cursor: pointer;
   }
-  &:hover { 
+  &:hover {
     img {
       border-bottom: 1px solid $highlight;
       filter: saturate(100%) contrast(100%);
     }
   }
-  &:focus { 
+  &:focus {
     img {
       border-bottom: 2px solid $highlight;
       padding-bottom: 4px;
@@ -379,7 +379,7 @@ $transition: 0.3s ease;
 
 
 // BASE STYLES
-  
+
 html {
   position: relative;
   min-width: 320px;
@@ -598,7 +598,7 @@ header {
     }
     z-index: 10;
     h1, h2, h3, h4, h5, h6,
-    p, ol, ul, div, 
+    p, ol, ul, div,
     blockquote, quote {
       margin-bottom: $gutter;
     }

--- a/index.markdown
+++ b/index.markdown
@@ -66,6 +66,5 @@ Join Together Co-operative is four technologists with a passion for the union mo
 
 [![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://www.cwu.org)
 [![Bakers Food and Allied Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/bfawu-logo.png)](https://www.bfawu.org)
-[![Writers Guild of Great Britain]({{ site.url }}{{ site.baseurl }}/assets/images/wggb-logo.jpg)](https://writersguild.org.uk)
 [![Forsa the Irish Trade Union]({{ site.url }}{{ site.baseurl }}/assets/images/forsa-logo.png)](https://www.forsa.ie)
 [![Trade Union Congress]({{ site.url }}{{ site.baseurl }}/assets/images/tuc-logo.jpg)](https://www.tuc.org.uk)

--- a/index.markdown
+++ b/index.markdown
@@ -64,7 +64,7 @@ We charge a one-time initial design and build fee, then a fixed monthly subscrip
 Join Together Co-operative is four technologists with a passion for the union movement, and a combined seven decades' experience delivering world class online web services.
 [Learn more about the team](/team).
 
-[![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://www.cwu.org)
-[![Bakers Food and Allied Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/bfawu-logo.png)](https://www.bfawu.org)
+[![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://join.cwu.org)
+[![Bakers Food and Allied Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/bfawu-logo.png)](https://join.bfawu.org)
 [![Forsa the Irish Trade Union]({{ site.url }}{{ site.baseurl }}/assets/images/forsa-logo.png)](https://www.forsa.ie)
 [![Trade Union Congress]({{ site.url }}{{ site.baseurl }}/assets/images/tuc-logo.jpg)](https://www.tuc.org.uk)

--- a/index.markdown
+++ b/index.markdown
@@ -9,10 +9,8 @@ paragraphs:
   - text: 'Stop losing members to a bad joining experience'
   - text: 'Get more members with online join that’s a delight, not a pain'
 buttons:
-  - label: 'Book a call'
+  - label: 'Book a call to discuss your online join'
     url: 'https://calendly.com/join-together/hello'
-  - label: 'Union joining tools'
-    url: '/joining-tool'
 ---
 
 ## What makes Join Together so special?

--- a/index.markdown
+++ b/index.markdown
@@ -4,11 +4,10 @@ title: Digital Tools for Trade Unions
 description:
   Join Together helps unions gain and maintain more members through digital
   tools and services designed for and with unions. Supported by the TUC.
-paragraphs: 
-  - text: 'Digital tools for <br>trade&nbsp;unions'
-  - text: 'We want to make joining a trade union quicker, easier and more accessible'
-  - text: 'Because bigger unions with&nbsp;more members can help reshape our politics'
-  - text: 'Better work for <br>everyone'
+paragraphs:
+  - text: 'Online join for <br>trade&nbsp;unions'
+  - text: 'Stop losing members to a bad joining experience'
+  - text: 'Get more members with online join that’s a delight, not a pain'
 buttons:
   - label: 'Book a call'
     url: 'https://calendly.com/join-together/hello'
@@ -16,16 +15,57 @@ buttons:
     url: '/joining-tool'
 ---
 
-## Join Together helps unions get more members&nbsp;by:
+## What makes Join Together so special?
 
-- Turning effective workplace organising and great campaigns into more members by making it quick and easy for people to join
-- Giving prospective members a great first impression of joining a union
-- Reducing member attrition and increasing revenue, by making it straightforward for people to update their contact information, payment details and their subs rate
-- Being designed and built for unions, fully hosted, secure, scalable and continually optimised to get better and better over time
-- Being built by a team who get unions
+Put simply, we are **100% focused on building the gold standard online joining experience for unions**. Every union has its own unique needs and requirements. We work with you and your team to tailor the perfect online joining experience for you and your members.
 
-[![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://www.cwu.org) 
-[![Bakers Food and Allied Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/bfawu-logo.png)](https://www.bfawu.org) 
-[![Writers Guild of Great Britain]({{ site.url }}{{ site.baseurl }}/assets/images/wggb-logo.jpg)](https://writersguild.org.uk) 
-[![Forsa the Irish Trade Union]({{ site.url }}{{ site.baseurl }}/assets/images/forsa-logo.png)](https://www.forsa.ie) 
-[![Trade Union Congress]({{ site.url }}{{ site.baseurl }}/assets/images/tuc-logo.jpg)](https://www.tuc.org.uk) 
+## Online join that is optimised to get you more members
+
+We sweat the details so that your online join gets you more members: 60% of applicants that start a Join Together join form go on to submit their application. How many extra members would your union get with a form that converted that well?
+
+## Bespoke forms that handle all the complexities of joining your union
+
+Whether it’s employer/sector-specific questions, complex rate calculation rules, deduction at source, or Direct Debit, the Join Together platform adapts to meet all the specific joining needs of your union.
+
+## Seamless integration with your existing CRM and processes
+
+Join Together lives in harmony alongside your existing membership system, and is able to automatically feed new applications directly into your CRM ready for your membership team to process. Including Salesforce, Dynamics365, APT Stratum, Wild Apricot and more.
+
+## Works alongside your website
+
+The Join Together system can be fully customised to fit with your existing brand and website, guaranteeing a smooth user experience for visitors joining your union – from your logo to brand colours, fonts and more.
+
+## Built to work beautifully on mobile and desktop
+
+With as many as 50% of applicants using a mobile device, you cannot afford to offer a substandard experience to mobile users. Join Together’s forms work perfectly across all devices.
+
+## Accessible and inclusive by default
+
+Our forms are designed to meet the W3C Web Accessibility guidelines, ensuring everyone – no matter their particular access needs – is able to join your union online.
+
+## Data ethics & security as standard
+
+Designed from the ground up to minimise the spread and retention of personal data, Join Together protects your data. Automatic encryption and banking-grade security keeps application data safe in a secure, access-managed location. [Learn more about our security](/information-security).
+
+## A fully hosted and maintained service
+
+We support and maintain the Join Together platform so you don't have to, ensuring it's always up to date, secure, and available when your members need it.
+
+## Fast and scalable
+
+Not only is the Join Together platform designed and built to be lightning fast, it automatically scales up to remain online and responsive, even during busy periods.
+
+## **Fair and transparent union-friendly pricing**
+
+We charge a one-time initial design and build fee, then a fixed monthly subscription to cover ongoing operations and support. Pricing is based on the expected number of monthly applications: smaller unions with fewer resources pay less; larger ones who use more, pay more, just like they would in a union!
+
+## Brought to you by a team that cares about unions
+
+Join Together Co-operative is four technologists with a passion for the union movement, and a combined seven decades' experience delivering world class online web services.
+[Learn more about the team](/team).
+
+[![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://www.cwu.org)
+[![Bakers Food and Allied Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/bfawu-logo.png)](https://www.bfawu.org)
+[![Writers Guild of Great Britain]({{ site.url }}{{ site.baseurl }}/assets/images/wggb-logo.jpg)](https://writersguild.org.uk)
+[![Forsa the Irish Trade Union]({{ site.url }}{{ site.baseurl }}/assets/images/forsa-logo.png)](https://www.forsa.ie)
+[![Trade Union Congress]({{ site.url }}{{ site.baseurl }}/assets/images/tuc-logo.jpg)](https://www.tuc.org.uk)

--- a/index.markdown
+++ b/index.markdown
@@ -59,7 +59,7 @@ We charge a one-time initial design and build fee, then a fixed monthly subscrip
 
 ## Brought to you by a team that cares about unions
 
-Join Together Co-operative is four technologists with a passion for the union movement, and a combined seven decades' experience delivering world class online web services.
+Join Together Co-operative is four technologists with a passion for the union movement, and a combined eight decades' experience delivering world class online web services.
 [Learn more about the team](/team).
 
 [![The Communication Workers Union]({{ site.url }}{{ site.baseurl }}/assets/images/cwu-logo.svg)](https://join.cwu.org)

--- a/posts.markdown
+++ b/posts.markdown
@@ -9,19 +9,3 @@ exclude: true
 ---
 
 # Updates from Join Together
-
-People are turning to unions again.
-
-“Join a union” is a phrase you hear a lot more of than you would have done five years ago. It’s coming from every corner of society, in every part of the country - a recognition that for several decades capital has had it too easy, while labour has had it too tough. That the balance is wrong and needs correcting. That the cost of living is too high, and the wages to pay for it are too low. It’s a feeling that’s bubbling up. It’s happening.
-
-But there’s still a way to go to having a union movement that’s growing quickly, and becoming powerful enough to press for - and get - the wide-ranging change workers need. 
-
-We started Join Together as a co-operative with a focus on helping unions address technology challenges because we’ve worked with unions for years, and though we’re not ‘organisers’ (well, one of us is!) in the traditional sense, we’ve come to see ourselves playing a similar role.
-
-Our mission is to make it easier to join - and stay a member of - a union. We’ve created software that gives people a better online joining experience (the way most members want to join), so we can help unions recruit more members, get bigger - and win. 
-
-We can also make things easier for unions themselves. It should be simple to sign a member up, process their application, work out which branch they should be in, sort out their subs and show them how to play an active role. Again, Join Together helps with this.
-
-As we discover things that improve the experience for people joining one union, we can share it with all unions. As we make it quicker or cheaper for unions to get new members, we can share those improvements with the whole movement. And as every incremental advance compounds over weeks, months and years, Join Together becomes something that’s driven onwards by its own momentum. 
-
-Just like a union.


### PR DESCRIPTION
- Update the homepage with new content, just dumped in a as typography for now (so we can get the words right)
- Removed WGGB link for now (we should put it back when they're new join is actually live)
- Repurpose some content from /posts to the /teams page
- Stop linking to the now mostly redundant joining-tools page. Kept it around for the minute until we settle on the new content, but we should clean it (and the CSS) up if we're not going to be using it.

Here's a screenshot, although probably best viewed live from the server.

![new-homepage](https://user-images.githubusercontent.com/3687/233407156-69fdbafd-23a7-437f-8ace-24895dfb921e.png)
